### PR TITLE
Create full-width hero and floating navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
             font-family: 'Poppins', 'Inter', sans-serif;
         }
 
+        html {
+            scroll-behavior: smooth;
+        }
+
         * {
             box-sizing: border-box;
         }
@@ -44,7 +48,13 @@
         }
 
         header {
-            padding: 32px 24px 16px;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            padding: 24px 24px 16px;
+            background: linear-gradient(180deg, rgba(3, 2, 10, 0.92), rgba(3, 2, 10, 0.7));
+            backdrop-filter: blur(18px);
+            box-shadow: 0 30px 60px -45px rgba(0, 0, 0, 0.85);
         }
 
         .header-inner {
@@ -60,12 +70,21 @@
             border-radius: 20px;
             padding: 20px 28px;
             box-shadow: 0 18px 50px -25px rgba(0, 0, 0, 0.55);
+            position: relative;
         }
 
         .brand {
             display: flex;
             align-items: center;
             gap: 16px;
+        }
+
+        .brand a {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            color: inherit;
+            text-decoration: none;
         }
 
         .brand img {
@@ -80,10 +99,216 @@
             text-transform: uppercase;
         }
 
+        nav {
+            margin-left: auto;
+        }
+
+        .nav-toggle {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 44px;
+            height: 44px;
+            border-radius: 14px;
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            background: rgba(12, 9, 24, 0.6);
+            color: var(--text);
+            cursor: pointer;
+            transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+            margin-left: auto;
+        }
+
+        .nav-toggle:hover {
+            transform: translateY(-1px);
+            border-color: var(--accent);
+            box-shadow: 0 12px 30px -18px rgba(255, 203, 112, 0.6);
+        }
+
+        .nav-toggle span {
+            display: block;
+            width: 18px;
+            height: 2px;
+            background: currentColor;
+            position: relative;
+        }
+
+        .nav-toggle span::before,
+        .nav-toggle span::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            width: 100%;
+            height: 2px;
+            background: currentColor;
+            transition: transform 0.3s ease, top 0.3s ease, opacity 0.3s ease;
+        }
+
+        .nav-toggle span::before {
+            top: -6px;
+        }
+
+        .nav-toggle span::after {
+            top: 6px;
+        }
+
+        .nav-toggle[aria-expanded='true'] span {
+            background: transparent;
+        }
+
+        .nav-toggle[aria-expanded='true'] span::before {
+            top: 0;
+            transform: rotate(45deg);
+        }
+
+        .nav-toggle[aria-expanded='true'] span::after {
+            top: 0;
+            transform: rotate(-45deg);
+        }
+
+        .nav-links {
+            list-style: none;
+            margin: 0;
+            padding: 18px 20px;
+            position: absolute;
+            top: calc(100% + 12px);
+            left: 0;
+            right: 0;
+            display: none;
+            flex-direction: column;
+            gap: 12px;
+            background: rgba(10, 8, 25, 0.92);
+            border: 1px solid var(--border);
+            border-radius: 18px;
+            box-shadow: 0 22px 50px -30px rgba(0, 0, 0, 0.85);
+            z-index: 10;
+        }
+
+        .nav-links.is-open {
+            display: flex;
+        }
+
+        .nav-links li {
+            text-align: center;
+        }
+
+        .nav-links a {
+            color: var(--text);
+            text-decoration: none;
+            font-size: 0.78rem;
+            letter-spacing: 0.35em;
+            text-transform: uppercase;
+            transition: color 0.3s ease;
+        }
+
+        .nav-links a:hover {
+            color: var(--accent);
+        }
+
+        @media (min-width: 840px) {
+            .nav-toggle {
+                display: none;
+            }
+
+            .nav-links {
+                position: static;
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                gap: 28px;
+                padding: 0;
+                background: transparent;
+                border: none;
+                box-shadow: none;
+            }
+        }
+
         .tagline {
             font-size: 0.95rem;
             max-width: 480px;
             color: var(--muted);
+        }
+
+        .hero {
+            position: relative;
+            width: 100%;
+            min-height: clamp(440px, 70vh, 700px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(120px, 18vw, 200px) 24px clamp(100px, 12vw, 160px);
+            background: linear-gradient(120deg, rgba(3, 2, 10, 0.88), rgba(3, 2, 10, 0.35)),
+                url('tamara.jpg') center / cover no-repeat;
+        }
+
+        .hero-content {
+            width: 100%;
+            max-width: 1100px;
+            background: rgba(9, 6, 18, 0.6);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 28px;
+            padding: clamp(36px, 6vw, 64px);
+            display: grid;
+            gap: 20px;
+            box-shadow: 0 30px 80px -45px rgba(0, 0, 0, 0.85);
+            backdrop-filter: blur(14px);
+        }
+
+        .hero-label {
+            font-size: 0.75rem;
+            letter-spacing: 0.35em;
+            text-transform: uppercase;
+            color: var(--accent);
+        }
+
+        .hero-title {
+            margin: 0;
+            font-size: clamp(2.2rem, 5vw, 3.2rem);
+        }
+
+        .hero-text {
+            font-size: 1.05rem;
+            color: var(--muted);
+            max-width: 720px;
+        }
+
+        .hero-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            margin-top: 8px;
+        }
+
+        .ghost-button {
+            padding: 12px 30px;
+            border-radius: 999px;
+            font-size: 0.85rem;
+            letter-spacing: 0.25em;
+            text-transform: uppercase;
+            border: 1px solid rgba(255, 255, 255, 0.35);
+            color: var(--text);
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+        }
+
+        .ghost-button:hover {
+            background: rgba(255, 203, 112, 0.12);
+            border-color: var(--accent);
+            color: var(--accent);
+            transform: translateY(-1px);
+        }
+
+        @media (max-width: 600px) {
+            .hero-content {
+                padding: 28px;
+                gap: 18px;
+            }
+
+            .hero-actions {
+                gap: 12px;
+            }
         }
 
         main {
@@ -366,18 +591,42 @@
     <header>
         <div class="header-inner">
             <div class="brand">
-                <img src="logo-TAMARA.png" alt="Logotipo Tamara Kilpp" />
-                <span>Metodo Tamara Kilpp</span>
+                <a href="#inicio">
+                    <img src="logo-TAMARA.png" alt="Logotipo Tamara Kilpp" />
+                    <span>Metodo Tamara Kilpp</span>
+                </a>
             </div>
-            <p class="tagline">
-                Moda e estratégia para mulheres que desejam um guarda-roupa inteligente, autêntico e alinhado com a rotina real.
-            </p>
+            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation" aria-label="Abrir menu de navegação">
+                <span></span>
+            </button>
+            <nav id="primary-navigation">
+                <ul class="nav-links">
+                    <li><a href="#inicio">Início</a></li>
+                    <li><a href="#cursos">Cursos</a></li>
+                    <li><a href="#oque">O que é</a></li>
+                    <li><a href="#para-quem">Para quem</a></li>
+                    <li><a href="#quem-sou">Quem sou</a></li>
+                </ul>
+            </nav>
         </div>
     </header>
+    <section class="hero" id="inicio">
+        <div class="hero-content">
+            <span class="hero-label">Método Tamara Kilpp</span>
+            <h1 class="hero-title">Experiência de estilo para vestir sua história</h1>
+            <p class="hero-text">
+                Moda e estratégia para mulheres que desejam um guarda-roupa inteligente, autêntico e alinhado com a rotina real.
+            </p>
+            <div class="hero-actions">
+                <a class="button" href="#cursos">Explorar cursos</a>
+                <a class="ghost-button" href="#quem-sou">Conheça a Tamara</a>
+            </div>
+        </div>
+    </section>
     <main>
         <section id="cursos">
             <span class="section-label">Cursos em destaque</span>
-            <h1 class="section-title">Escolha o formato que transforma seu estilo de forma imediata</h1>
+            <h2 class="section-title">Escolha o formato que transforma seu estilo de forma imediata</h2>
             <p class="section-lead">
                 Dois programas completos para organizar seu guarda-roupa, dominar combinações e vestir sua personalidade todos os
                 dias. Cada caminho possui experiências exclusivas e acompanhamento próximo para garantir resultado.
@@ -473,7 +722,7 @@
         <section id="quem-sou">
             <div class="about-section">
                 <figure class="about-image">
-                    <img src="tamara.jpg" alt="Tamara Kilpp" />
+                    <img src="TAMA-161.jpg" alt="Tamara Kilpp" />
                 </figure>
                 <div class="about-content">
                     <span class="section-label">Quem sou</span>
@@ -499,5 +748,32 @@
     <footer>
         © 2024 Tamara Kilpp · Todos os direitos reservados.
     </footer>
+    <script>
+        const navToggle = document.querySelector('.nav-toggle');
+        const navLinks = document.querySelector('.nav-links');
+
+        if (navToggle && navLinks) {
+            navToggle.addEventListener('click', () => {
+                const isOpen = navLinks.classList.toggle('is-open');
+                navToggle.setAttribute('aria-expanded', String(isOpen));
+            });
+
+            navLinks.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', () => {
+                    if (window.innerWidth < 840 && navLinks.classList.contains('is-open')) {
+                        navLinks.classList.remove('is-open');
+                        navToggle.setAttribute('aria-expanded', 'false');
+                    }
+                });
+            });
+
+            window.addEventListener('resize', () => {
+                if (window.innerWidth >= 840 && navLinks.classList.contains('is-open')) {
+                    navLinks.classList.remove('is-open');
+                    navToggle.setAttribute('aria-expanded', 'false');
+                }
+            });
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement a sticky header featuring the Tamara logo, anchor navigation, and a hamburger menu for small screens
- add a full-width hero section that uses tamara.jpg as the backdrop with primary calls to action
- swap the "Quem sou" portrait to TAMA-161.jpg and include supporting scripting for the responsive navigation

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cd3ff1a11c832e84f007f54b00fa52