### PR TITLE
Ajusta layout da hero para respeitar a imagem de fundo

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,19 +231,63 @@
         .hero {
             position: relative;
             width: 100%;
-            min-height: clamp(440px, 70vh, 700px);
+            min-height: clamp(480px, 75vh, 760px);
             display: flex;
             align-items: center;
             justify-content: center;
             padding: clamp(120px, 18vw, 200px) 24px clamp(100px, 12vw, 160px);
-            background: linear-gradient(120deg, rgba(3, 2, 10, 0.88), rgba(3, 2, 10, 0.35)),
-                url('tamara.jpg') center / cover no-repeat;
+            background: var(--bg);
+            overflow: hidden;
+            isolation: isolate;
+        }
+
+        .hero::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(120deg, rgba(3, 2, 10, 0.9), rgba(3, 2, 10, 0.45));
+            z-index: 0;
+        }
+
+        .hero-inner {
+            position: relative;
+            z-index: 1;
+            width: 100%;
+            max-width: 1100px;
+            display: grid;
+            grid-template-columns: minmax(0, 1fr);
+            align-items: center;
+            gap: clamp(32px, 6vw, 72px);
+        }
+
+        .hero-media {
+            position: relative;
+            border-radius: 32px;
+            overflow: hidden;
+            min-height: clamp(320px, 45vh, 520px);
+            box-shadow: 0 40px 90px -48px rgba(0, 0, 0, 0.8);
+        }
+
+        .hero-media::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(150deg, rgba(3, 2, 10, 0.35) 0%, rgba(3, 2, 10, 0.1) 55%, rgba(3, 2, 10, 0) 100%);
+            pointer-events: none;
+        }
+
+        .hero-media img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            object-position: center;
+            display: block;
         }
 
         .hero-content {
-            width: 100%;
-            max-width: 1100px;
-            background: rgba(9, 6, 18, 0.6);
+            width: min(100%, 560px);
+            margin: 0 auto;
+            background: rgba(9, 6, 18, 0.72);
             border: 1px solid rgba(255, 255, 255, 0.12);
             border-radius: 28px;
             padding: clamp(36px, 6vw, 64px);
@@ -251,6 +295,7 @@
             gap: 20px;
             box-shadow: 0 30px 80px -45px rgba(0, 0, 0, 0.85);
             backdrop-filter: blur(14px);
+            align-self: center;
         }
 
         .hero-label {
@@ -276,6 +321,24 @@
             flex-wrap: wrap;
             gap: 16px;
             margin-top: 8px;
+        }
+
+        @media (min-width: 768px) {
+            .hero-inner {
+                grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+            }
+
+            .hero-content {
+                margin: 0;
+                justify-self: end;
+            }
+        }
+
+        @media (min-width: 1080px) {
+            .hero-inner {
+                grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+                align-items: center;
+            }
         }
 
         .ghost-button {
@@ -611,15 +674,20 @@
         </div>
     </header>
     <section class="hero" id="inicio">
-        <div class="hero-content">
-            <span class="hero-label">Método Tamara Kilpp</span>
-            <h1 class="hero-title">Experiência de estilo para vestir sua história</h1>
-            <p class="hero-text">
-                Moda e estratégia para mulheres que desejam um guarda-roupa inteligente, autêntico e alinhado com a rotina real.
-            </p>
-            <div class="hero-actions">
-                <a class="button" href="#cursos">Explorar cursos</a>
-                <a class="ghost-button" href="#quem-sou">Conheça a Tamara</a>
+        <div class="hero-inner">
+            <div class="hero-media">
+                <img src="tamara.jpg" alt="Tamara Kilpp apresentando sua experiência de estilo" />
+            </div>
+            <div class="hero-content">
+                <span class="hero-label">Método Tamara Kilpp</span>
+                <h1 class="hero-title">Experiência de estilo para vestir sua história</h1>
+                <p class="hero-text">
+                    Moda e estratégia para mulheres que desejam um guarda-roupa inteligente, autêntico e alinhado com a rotina real.
+                </p>
+                <div class="hero-actions">
+                    <a class="button" href="#cursos">Explorar cursos</a>
+                    <a class="ghost-button" href="#quem-sou">Conheça a Tamara</a>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- reorganiza a seção hero para usar grid com imagem dedicada e bloco de texto sem sobreposição do rosto
- ajusta espaçamentos, gradientes e breakpoints para manter contraste e responsividade entre mobile e telas maiores

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_68cd429427ac832e8c52bb967e116334