### PR TITLE
Adjust hero overlay transparency and WhatsApp CTA styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
         .hero-content {
             width: min(100%, 560px);
             margin: 0;
-            background: rgba(9, 6, 18, 0.72);
+            background: rgba(9, 6, 18, 0.55);
             border: 1px solid rgba(255, 255, 255, 0.12);
             border-radius: 28px;
             padding: clamp(36px, 6vw, 64px);
@@ -681,11 +681,11 @@
             width: 62px;
             height: 62px;
             border-radius: 50%;
-            background: linear-gradient(135deg, rgba(37, 211, 102, 0.92), rgba(16, 163, 73, 0.92));
+            background: transparent;
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            box-shadow: 0 18px 40px -22px rgba(16, 163, 73, 0.85);
+            box-shadow: none;
             z-index: 1500;
             text-decoration: none;
             transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -693,12 +693,12 @@
 
         .whatsapp-floating:hover {
             transform: translateY(-2px);
-            box-shadow: 0 22px 44px -22px rgba(37, 211, 102, 0.9);
+            box-shadow: none;
         }
 
         .whatsapp-floating img {
-            width: 34px;
-            height: 34px;
+            width: 44px;
+            height: 44px;
         }
 
         .sr-only {


### PR DESCRIPTION
## Summary
- lighten the hero content panel overlay so more of the background portrait remains visible
- remove the background fill from the WhatsApp floating button and enlarge its icon for a cleaner transparent look

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cd697afe34832e8c98217b4900272f