### PR TITLE
Harmonize hero and footer backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,8 +370,8 @@
         .hero-content {
             width: min(100%, 560px);
             margin: 0;
-            background: rgba(9, 6, 18, 0.55);
-            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: var(--card);
+            border: 1px solid var(--border);
             border-radius: 28px;
             padding: clamp(36px, 6vw, 64px);
             display: grid;
@@ -731,6 +731,12 @@
             flex-direction: column;
             align-items: center;
             gap: 24px;
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 28px;
+            padding: 32px;
+            box-shadow: 0 30px 70px -44px rgba(0, 0, 0, 0.75);
+            backdrop-filter: blur(14px);
         }
 
         .footer-inner p {


### PR DESCRIPTION
## Summary
- padroniza o fundo da caixa de conteúdo da seção hero usando o tom semitransparente definido para cartões
- aplica o mesmo tom ao bloco interno do rodapé, com borda, raio e blur para manter a harmonia visual

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d457eec4d0832eb1e58641513f2fe2