### PR TITLE
Remover caixa de destaque do rodapé

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,12 +730,7 @@
             flex-direction: column;
             align-items: center;
             gap: 24px;
-            background: var(--card);
-            border: 1px solid var(--border);
-            border-radius: 28px;
             padding: 32px;
-            box-shadow: 0 30px 70px -44px rgba(0, 0, 0, 0.75);
-            backdrop-filter: blur(14px);
         }
 
         .footer-inner p {


### PR DESCRIPTION
## Sumário
- remove o fundo, borda e sombra da caixa do rodapé para deixá-lo limpo

## Testes
- nenhum teste foi executado; mudanças apenas de estilo

------
https://chatgpt.com/codex/tasks/task_e_68d53c7703a8832e8800d425ed390131