### PR TITLE
Add cross-origin leads API support

### DIFF
--- a/lead-storage.js
+++ b/lead-storage.js
@@ -1,5 +1,144 @@
 (function () {
-    const API_BASE = '/api/leads';
+    const API_PATH = '/api/leads';
+
+    const normalizeUrl = (value) => {
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        const trimmed = value.trim();
+
+        if (!trimmed) {
+            return null;
+        }
+
+        try {
+            if (typeof window !== 'undefined' && window.location) {
+                const url = new URL(trimmed, window.location.href);
+                return url.toString().replace(/\/$/, '');
+            }
+
+            const url = new URL(trimmed);
+            return url.toString().replace(/\/$/, '');
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const normalizeApiBase = (value) => {
+        const normalized = normalizeUrl(value);
+
+        if (!normalized) {
+            return null;
+        }
+
+        if (normalized.endsWith(API_PATH)) {
+            return normalized;
+        }
+
+        return `${normalized}${API_PATH}`;
+    };
+
+    const getMetaContent = (name) => {
+        if (typeof document === 'undefined') {
+            return '';
+        }
+
+        const element = document.querySelector(`meta[name="${name}"]`);
+
+        if (!element || typeof element.content !== 'string') {
+            return '';
+        }
+
+        return element.content.trim();
+    };
+
+    const getDatasetOverride = () => {
+        if (typeof document === 'undefined') {
+            return null;
+        }
+
+        const candidates = [];
+
+        if (document.currentScript && document.currentScript.dataset) {
+            candidates.push(document.currentScript.dataset.tkLeadsApiBase);
+            candidates.push(document.currentScript.dataset.tkLeadsApiOrigin);
+        }
+
+        const fallbackScript = document.querySelector('script[data-tk-leads-api-base], script[data-tk-leads-api-origin]');
+
+        if (fallbackScript && fallbackScript.dataset) {
+            candidates.push(fallbackScript.dataset.tkLeadsApiBase);
+            candidates.push(fallbackScript.dataset.tkLeadsApiOrigin);
+        }
+
+        for (const value of candidates) {
+            if (typeof value === 'string' && value.trim()) {
+                return value.trim();
+            }
+        }
+
+        return null;
+    };
+
+    const getWindowOverride = () => {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        const { tkLeadsApiBase, tkLeadsApiOrigin, TK_LEADS_API_BASE, TK_LEADS_API_ORIGIN } = window;
+        const override =
+            (typeof tkLeadsApiBase === 'string' && tkLeadsApiBase.trim()) ||
+            (typeof TK_LEADS_API_BASE === 'string' && TK_LEADS_API_BASE.trim()) ||
+            (typeof tkLeadsApiOrigin === 'string' && tkLeadsApiOrigin.trim()) ||
+            (typeof TK_LEADS_API_ORIGIN === 'string' && TK_LEADS_API_ORIGIN.trim());
+
+        return override ? override.trim() : null;
+    };
+
+    const resolveApiBase = () => {
+        const explicitOverride = getWindowOverride() || getDatasetOverride();
+
+        if (explicitOverride) {
+            const normalized = normalizeApiBase(explicitOverride);
+
+            if (normalized) {
+                return normalized;
+            }
+        }
+
+        const metaBase = getMetaContent('tk:leads-api-base');
+
+        if (metaBase) {
+            const normalized = normalizeApiBase(metaBase);
+
+            if (normalized) {
+                return normalized;
+            }
+        }
+
+        const metaOrigin = getMetaContent('tk:leads-api-origin');
+
+        if (metaOrigin) {
+            const normalized = normalizeApiBase(metaOrigin);
+
+            if (normalized) {
+                return normalized;
+            }
+        }
+
+        if (typeof window !== 'undefined' && window.location) {
+            const normalized = normalizeApiBase(window.location.origin);
+
+            if (normalized) {
+                return normalized;
+            }
+        }
+
+        return API_PATH;
+    };
+
+    const API_BASE = resolveApiBase();
 
     const getPhoneDigits = (value = '') => value.replace(/\D/g, '');
 
@@ -89,6 +228,7 @@
     };
 
     window.tkLeadStorage = {
+        apiBase: API_BASE,
         getPhoneDigits,
         registerLead,
         fetchLeads,

--- a/server.js
+++ b/server.js
@@ -213,23 +213,49 @@ const upsertLead = async (payload) => {
     return normalizedLead;
 };
 
-const sendJson = (res, statusCode, data) => {
+const buildCorsHeaders = (req, additionalHeaders = {}) => {
+    const originHeader = req.headers.origin;
+    const allowOrigin = originHeader && originHeader !== 'null' ? originHeader : '*';
+    const requestedHeaders = req.headers['access-control-request-headers'];
+
+    return {
+        Vary: 'Origin',
+        'Access-Control-Allow-Origin': allowOrigin,
+        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+        'Access-Control-Allow-Headers': requestedHeaders || 'Accept, Content-Type',
+        'Access-Control-Max-Age': '86400',
+        'Access-Control-Expose-Headers': 'Content-Disposition',
+        ...additionalHeaders,
+    };
+};
+
+const sendOptions = (req, res) => {
+    const headers = buildCorsHeaders(req, {
+        'Content-Length': '0',
+        'Cache-Control': 'no-store',
+    });
+
+    res.writeHead(204, headers);
+    res.end();
+};
+
+const sendJson = (req, res, statusCode, data) => {
     const payload = JSON.stringify(data);
-    res.writeHead(statusCode, {
+    res.writeHead(statusCode, buildCorsHeaders(req, {
         'Content-Type': 'application/json; charset=utf-8',
         'Content-Length': Buffer.byteLength(payload),
         'Cache-Control': 'no-store',
-    });
+    }));
     res.end(payload);
 };
 
-const sendText = (res, statusCode, message) => {
+const sendText = (req, res, statusCode, message) => {
     const payload = message;
-    res.writeHead(statusCode, {
+    res.writeHead(statusCode, buildCorsHeaders(req, {
         'Content-Type': 'text/plain; charset=utf-8',
         'Content-Length': Buffer.byteLength(payload),
         'Cache-Control': 'no-store',
-    });
+    }));
     res.end(payload);
 };
 
@@ -257,15 +283,24 @@ const serveStaticFile = async (res, filePath) => {
 };
 
 const handleApiRequest = async (req, res, url) => {
+    if (!url.pathname.startsWith('/api/')) {
+        return false;
+    }
+
+    if (req.method === 'OPTIONS') {
+        sendOptions(req, res);
+        return true;
+    }
+
     if (req.method === 'POST' && url.pathname === '/api/leads') {
         try {
             const body = await parseJsonBody(req);
             await upsertLead(body);
-            sendJson(res, 201, { success: true });
+            sendJson(req, res, 201, { success: true });
         } catch (error) {
             console.error('Erro ao registrar lead:', error);
             const status = error.statusCode && Number.isInteger(error.statusCode) ? error.statusCode : 500;
-            sendJson(res, status, { success: false, message: error.message || 'Erro interno ao salvar o contato.' });
+            sendJson(req, res, status, { success: false, message: error.message || 'Erro interno ao salvar o contato.' });
         }
 
         return true;
@@ -274,10 +309,10 @@ const handleApiRequest = async (req, res, url) => {
     if (req.method === 'GET' && url.pathname === '/api/leads') {
         try {
             const leads = await readLeadsFromCsv();
-            sendJson(res, 200, { leads });
+            sendJson(req, res, 200, { leads });
         } catch (error) {
             console.error('Erro ao ler leads:', error);
-            sendJson(res, 500, { success: false, message: 'Erro ao carregar os contatos.' });
+            sendJson(req, res, 500, { success: false, message: 'Erro ao carregar os contatos.' });
         }
 
         return true;
@@ -287,17 +322,16 @@ const handleApiRequest = async (req, res, url) => {
         try {
             await ensureCsvFile();
             const content = await fs.readFile(CSV_FILE);
-            res.writeHead(200, {
+            res.writeHead(200, buildCorsHeaders(req, {
                 'Content-Type': 'text/csv; charset=utf-8',
                 'Content-Length': content.length,
                 'Content-Disposition': 'attachment; filename="leads.csv"',
                 'Cache-Control': 'no-store',
-            });
+            }));
             res.end(content);
         } catch (error) {
             console.error('Erro ao enviar CSV:', error);
-            res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
-            res.end('Erro ao gerar o arquivo CSV.');
+            sendText(req, res, 500, 'Erro ao gerar o arquivo CSV.');
         }
 
         return true;
@@ -322,7 +356,7 @@ const server = http.createServer(async (req, res) => {
     const filePath = path.join(ROOT_DIR, pathname);
 
     if (!filePath.startsWith(ROOT_DIR)) {
-        sendText(res, 403, 'Acesso negado.');
+        sendText(req, res, 403, 'Acesso negado.');
         return;
     }
 


### PR DESCRIPTION
## Summary
- make the browser lead helper auto-detect the API base using overrides, meta tags, and location fallbacks so pages work from other origins
- expose the resolved API base to callers and reuse it for CSV downloads
- add reusable CORS helpers plus OPTIONS handling to send cross-origin headers on every leads API response

## Testing
- node server.js (terminated after startup)


------
https://chatgpt.com/codex/tasks/task_e_68e006b234b4832e9d4e03051ed8abcd