### PR TITLE
Fix admin lead export by aligning CSV format

### DIFF
--- a/leads.php
+++ b/leads.php
@@ -12,22 +12,22 @@ if (!$input || !isset($input["nome"]) || !isset($input["telefone"]) || !isset($i
     exit;
 }
 
-$nome = $input["nome"];
-$telefone = $input["telefone"];
-$email = $input["email"];
-$instagram = isset($input["instagram"]) ? $input["instagram"] : "";
+$nome = trim($input["nome"]);
+$telefone = trim($input["telefone"]);
+$email = trim($input["email"]);
+$instagram = isset($input["instagram"]) ? trim($input["instagram"]) : "";
 
 $arquivo = __DIR__ . "/leads.csv";
 
 if (!file_exists($arquivo)) {
-    $cabecalho = ["Nome", "Telefone", "Email", "Instagram", "Data Registro"];
+    $cabecalho = ["NAME", "EMAIL", "PHONE", "INSTAGRAM", "CAPTURED_AT"];
     $fp = fopen($arquivo, "w");
-    fputcsv($fp, $cabecalho, ";");
+    fputcsv($fp, $cabecalho);
     fclose($fp);
 }
 
 $fp = fopen($arquivo, "a");
-fputcsv($fp, [$nome, $telefone, $email, $instagram, date("Y-m-d H:i:s")], ";");
+fputcsv($fp, [$nome, $email, $telefone, $instagram, date("c")]);
 fclose($fp);
 
 http_response_code(201);

--- a/server.js
+++ b/server.js
@@ -84,7 +84,7 @@ const escapeCsvValue = (value = '') => {
     return normalized;
 };
 
-const parseCsvLine = (line = '') => {
+const parseCsvLine = (line = '', delimiter = ',') => {
     const result = [];
     let current = '';
     let insideQuotes = false;
@@ -101,7 +101,7 @@ const parseCsvLine = (line = '') => {
             } else {
                 insideQuotes = !insideQuotes;
             }
-        } else if (char === ',' && !insideQuotes) {
+        } else if (char === delimiter && !insideQuotes) {
             result.push(current);
             current = '';
         } else {
@@ -122,14 +122,87 @@ const readLeadsFromCsv = async () => {
             return [];
         }
 
-        const [, ...rows] = lines;
+        const [rawHeader, ...rows] = lines;
+        const delimiter = (() => {
+            const firstDataRow = rows[0] || '';
+            const commaCount = (rawHeader.match(/,/g) || []).length + (firstDataRow.match(/,/g) || []).length;
+            const semicolonCount =
+                (rawHeader.match(/;/g) || []).length + (firstDataRow.match(/;/g) || []).length;
+
+            if (semicolonCount > commaCount) {
+                return ';';
+            }
+
+            if (commaCount > 0) {
+                return ',';
+            }
+
+            if (semicolonCount > 0) {
+                return ';';
+            }
+
+            // Default fallback when header does not contain delimiters.
+            return ',';
+        })();
+
+        const normalizeHeaderName = (value = '') =>
+            value
+                .toString()
+                .trim()
+                .toLowerCase()
+                .normalize('NFD')
+                .replace(/[\u0300-\u036f]/g, '')
+                .replace(/\s+/g, '_');
+
+        const resolveHeaderKey = (value = '') => {
+            const normalized = normalizeHeaderName(value);
+
+            if (['name', 'nome'].includes(normalized)) {
+                return 'name';
+            }
+
+            if (['email'].includes(normalized)) {
+                return 'email';
+            }
+
+            if (['phone', 'telefone', 'telefone_whatsapp', 'telefone_whats'].includes(normalized)) {
+                return 'phone';
+            }
+
+            if (['instagram', 'instagram_', 'instagram_handle'].includes(normalized)) {
+                return 'instagram';
+            }
+
+            if (
+                ['captured_at', 'data_registro', 'data_de_registro', 'registrado_em', 'capturado_em'].includes(
+                    normalized
+                )
+            ) {
+                return 'captured_at';
+            }
+
+            return null;
+        };
+
+        const headerColumns = parseCsvLine(rawHeader, delimiter);
+        const headerMap = headerColumns.map((column) => resolveHeaderKey(column));
 
         return rows.map((line) => {
-            const values = parseCsvLine(line);
+            const values = parseCsvLine(line, delimiter);
             const entry = {};
 
-            CSV_HEADERS.forEach((key, index) => {
+            headerMap.forEach((key, index) => {
+                if (!key) {
+                    return;
+                }
+
                 entry[key] = values[index] ?? '';
+            });
+
+            CSV_HEADERS.forEach((key) => {
+                if (entry[key] === undefined) {
+                    entry[key] = '';
+                }
             });
 
             return entry;


### PR DESCRIPTION
## Summary
- normalize the Node server's CSV parser to support comma- and semicolon-delimited headers used by previous exports
- align the PHP fallback writer with the Node API format so leads are saved in a consistent column order and timestamp format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0165aa330832ea6ce1051fc616da7