### PR TITLE
Improve admin lead export fallbacks

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -300,7 +300,7 @@
         const leadStorage = window.tkLeadStorage || {};
         const {
             fetchLeads = async () => [],
-            downloadLeadsCsv = () => {},
+            downloadLeadsCsv = async () => {},
         } = leadStorage;
         let cachedLeads = [];
 
@@ -470,7 +470,7 @@
                     return;
                 }
 
-                downloadLeadsCsv();
+                await downloadLeadsCsv();
             } catch (error) {
                 console.error('Erro ao exportar os contatos.', error);
                 window.alert('Não foi possível exportar os contatos. Verifique a conexão com o servidor.');

--- a/lead-storage.js
+++ b/lead-storage.js
@@ -2,6 +2,7 @@
     const API_PATH = '/api/leads';
     const FALLBACK_ENDPOINTS = ['./leads.php', '/leads.php', '/api/leads', '/leads'];
     let cachedRegisterEndpoint = null;
+    let cachedFetchEndpoint = null;
 
     const normalizeUrl = (value) => {
         if (typeof value !== 'string') {
@@ -516,23 +517,163 @@
     };
 
     const fetchLeads = async () => {
-        const data = await request(API_BASE, { method: 'GET' });
+        const endpointsToTry = [];
 
-        if (!data || !Array.isArray(data.leads)) {
-            return [];
+        const appendCandidate = (value) => {
+            if (typeof value !== 'string') {
+                return;
+            }
+
+            const trimmed = value.trim();
+
+            if (!trimmed) {
+                return;
+            }
+
+            if (!endpointsToTry.includes(trimmed)) {
+                endpointsToTry.push(trimmed);
+            }
+        };
+
+        if (cachedFetchEndpoint) {
+            appendCandidate(cachedFetchEndpoint);
         }
 
-        return data.leads;
+        appendCandidate(API_BASE);
+        FALLBACK_ENDPOINTS.forEach(appendCandidate);
+        appendCandidate('./leads.php');
+        appendCandidate('/leads.php');
+
+        let lastError = null;
+
+        for (const endpoint of endpointsToTry) {
+            try {
+                const data = await request(endpoint, { method: 'GET' });
+
+                if (data && Array.isArray(data.leads)) {
+                    cachedFetchEndpoint = endpoint;
+                    return data.leads;
+                }
+            } catch (error) {
+                lastError = error;
+
+                if (error && error.status === 404) {
+                    continue;
+                }
+
+                throw error;
+            }
+        }
+
+        if (lastError) {
+            throw lastError;
+        }
+
+        return [];
     };
 
-    const downloadLeadsCsv = () => {
-        const url = `${API_BASE}.csv?timestamp=${Date.now()}`;
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'leads.csv';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+    const downloadLeadsCsv = async () => {
+        const endpointsToTry = [];
+
+        const appendCandidate = (value) => {
+            if (typeof value !== 'string') {
+                return;
+            }
+
+            const trimmed = value.trim();
+
+            if (!trimmed) {
+                return;
+            }
+
+            if (!endpointsToTry.includes(trimmed)) {
+                endpointsToTry.push(trimmed);
+            }
+        };
+
+        const appendVariants = (base) => {
+            if (typeof base !== 'string') {
+                return;
+            }
+
+            const trimmed = base.trim();
+
+            if (!trimmed) {
+                return;
+            }
+
+            const hasQuery = trimmed.includes('?');
+            const appendQueryVariant = (suffix) => {
+                const separator = hasQuery ? '&' : '?';
+                appendCandidate(`${trimmed}${separator}${suffix}`);
+            };
+
+            if (!/\.php(\b|$)/i.test(trimmed)) {
+                appendCandidate(`${trimmed}.csv`);
+            }
+
+            appendQueryVariant('format=csv');
+            appendQueryVariant('download=1');
+        };
+
+        if (cachedFetchEndpoint) {
+            appendVariants(cachedFetchEndpoint);
+        }
+
+        appendVariants(API_BASE);
+        FALLBACK_ENDPOINTS.forEach((endpoint) => {
+            appendVariants(endpoint);
+        });
+        appendVariants('./leads.php');
+        appendVariants('/leads.php');
+        appendCandidate('./leads.csv');
+        appendCandidate('/leads.csv');
+
+        let lastError = null;
+
+        for (const endpoint of endpointsToTry) {
+            try {
+                const url = endpoint.includes('?')
+                    ? `${endpoint}&ts=${Date.now()}`
+                    : `${endpoint}?ts=${Date.now()}`;
+                const response = await fetch(url, {
+                    method: 'GET',
+                    headers: {
+                        Accept: 'text/csv, text/plain;q=0.9, */*;q=0.8',
+                    },
+                    cache: 'no-store',
+                });
+
+                if (!response.ok) {
+                    lastError = new Error(`Falha ao baixar CSV (${response.status}).`);
+
+                    if (response.status === 404) {
+                        continue;
+                    }
+
+                    break;
+                }
+
+                const blob = await response.blob();
+                const downloadUrl = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = downloadUrl;
+                link.download = 'leads.csv';
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(downloadUrl);
+                return;
+            } catch (error) {
+                lastError = error;
+            }
+        }
+
+        if (lastError) {
+            throw lastError;
+        }
+
+        throw new Error('Não foi possível gerar o arquivo CSV.');
     };
 
     window.tkLeadStorage = {

--- a/leads.php
+++ b/leads.php
@@ -1,34 +1,298 @@
 <?php
-header("Access-Control-Allow-Origin: *");
-header("Access-Control-Allow-Methods: POST");
-header("Access-Control-Allow-Headers: Content-Type");
-header("Content-Type: application/json; charset=UTF-8");
+$CSV_FILE = __DIR__ . '/leads.csv';
+$CSV_HEADERS = ['name', 'email', 'phone', 'instagram', 'captured_at'];
 
-$input = json_decode(file_get_contents("php://input"), true);
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET,POST,OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Accept');
+header('Access-Control-Expose-Headers: Content-Disposition');
 
-if (!$input || !isset($input["nome"]) || !isset($input["telefone"]) || !isset($input["email"])) {
-    http_response_code(400);
-    echo json_encode(["error" => "Dados inválidos"]);
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    header('Content-Length: 0');
     exit;
 }
 
-$nome = $input["nome"];
-$telefone = $input["telefone"];
-$email = $input["email"];
-$instagram = isset($input["instagram"]) ? $input["instagram"] : "";
-
-$arquivo = __DIR__ . "/leads.csv";
-
-if (!file_exists($arquivo)) {
-    $cabecalho = ["Nome", "Telefone", "Email", "Instagram", "Data Registro"];
-    $fp = fopen($arquivo, "w");
-    fputcsv($fp, $cabecalho, ";");
-    fclose($fp);
+function ensure_csv_file($path, $headers)
+{
+    if (!file_exists($path)) {
+        $headerLine = implode(',', array_map('strtoupper', $headers));
+        file_put_contents($path, $headerLine . "\n", LOCK_EX);
+    }
 }
 
-$fp = fopen($arquivo, "a");
-fputcsv($fp, [$nome, $telefone, $email, $instagram, date("Y-m-d H:i:s")], ";");
-fclose($fp);
+function detect_delimiter($headerLine, $firstDataLine)
+{
+    $commaCount = substr_count($headerLine, ',') + substr_count($firstDataLine, ',');
+    $semicolonCount = substr_count($headerLine, ';') + substr_count($firstDataLine, ';');
 
-http_response_code(201);
-echo json_encode(["success" => true, "message" => "Lead registrado com sucesso"]);
+    if ($semicolonCount > $commaCount) {
+        return ';';
+    }
+
+    if ($commaCount > 0) {
+        return ',';
+    }
+
+    if ($semicolonCount > 0) {
+        return ';';
+    }
+
+    return ',';
+}
+
+function normalize_header_name($value)
+{
+    $base = strtolower(trim((string) $value));
+    $normalized = $base;
+
+    if (function_exists('iconv')) {
+        $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $base);
+
+        if ($transliterated !== false) {
+            $normalized = $transliterated;
+        }
+    }
+
+    $normalized = preg_replace('/[^a-z0-9]+/i', '_', $normalized);
+    return trim($normalized, '_');
+}
+
+function resolve_header_key($value)
+{
+    $normalized = normalize_header_name($value);
+
+    $map = [
+        'name' => ['name', 'nome'],
+        'email' => ['email'],
+        'phone' => ['phone', 'telefone', 'telefone_whatsapp', 'telefone_whats'],
+        'instagram' => ['instagram', 'instagram_', 'instagram_handle'],
+        'captured_at' => ['captured_at', 'data_registro', 'data_de_registro', 'registrado_em', 'capturado_em'],
+    ];
+
+    foreach ($map as $key => $aliases) {
+        if (in_array($normalized, $aliases, true)) {
+            return $key;
+        }
+    }
+
+    return null;
+}
+
+function read_leads_from_csv($path, $headers)
+{
+    if (!file_exists($path)) {
+        return [];
+    }
+
+    $content = file_get_contents($path);
+
+    if ($content === false) {
+        throw new RuntimeException('Não foi possível ler o arquivo de leads.');
+    }
+
+    $content = trim($content);
+
+    if ($content === '') {
+        return [];
+    }
+
+    $lines = preg_split('/\r\n|\r|\n/', $content);
+
+    if (count($lines) <= 1) {
+        return [];
+    }
+
+    $rawHeader = array_shift($lines);
+    $rawHeader = preg_replace('/^\xEF\xBB\xBF/', '', $rawHeader);
+    $firstDataLine = $lines[0] ?? '';
+    $delimiter = detect_delimiter($rawHeader, $firstDataLine);
+    $headerColumns = str_getcsv($rawHeader, $delimiter);
+    $headerMap = array_map('resolve_header_key', $headerColumns);
+    $rows = [];
+
+    foreach ($lines as $line) {
+        if (!is_string($line) || trim($line) === '') {
+            continue;
+        }
+
+        $values = str_getcsv($line, $delimiter);
+        $entry = [];
+
+        foreach ($headerMap as $index => $key) {
+            if (!$key) {
+                continue;
+            }
+
+            $entry[$key] = $values[$index] ?? '';
+        }
+
+        foreach ($headers as $header) {
+            if (!array_key_exists($header, $entry)) {
+                $entry[$header] = '';
+            }
+        }
+
+        $rows[] = $entry;
+    }
+
+    return $rows;
+}
+
+function write_leads_to_csv($path, $headers, $leads)
+{
+    $lines = [];
+    $lines[] = implode(',', array_map('strtoupper', $headers));
+
+    foreach ($leads as $lead) {
+        $row = [];
+
+        foreach ($headers as $header) {
+            $value = isset($lead[$header]) ? (string) $lead[$header] : '';
+            $value = preg_replace("/(\r\n|\r|\n)/", ' ', $value);
+
+            if (strpos($value, '"') !== false || strpos($value, ',') !== false) {
+                $value = '"' . str_replace('"', '""', $value) . '"';
+            }
+
+            $row[] = $value;
+        }
+
+        $lines[] = implode(',', $row);
+    }
+
+    $payload = implode("\n", $lines) . "\n";
+
+    if (file_put_contents($path, $payload, LOCK_EX) === false) {
+        throw new RuntimeException('Não foi possível atualizar o arquivo de leads.');
+    }
+}
+
+function get_phone_digits($value)
+{
+    return preg_replace('/\D+/', '', $value ?? '');
+}
+
+function normalize_instagram($value)
+{
+    $trimmed = trim($value ?? '');
+
+    if ($trimmed === '') {
+        return '';
+    }
+
+    $sanitized = preg_replace('/^@+/', '', $trimmed);
+    return $sanitized !== '' ? '@' . $sanitized : '';
+}
+
+function normalize_input($input)
+{
+    $name = isset($input['name']) ? $input['name'] : (isset($input['nome']) ? $input['nome'] : '');
+    $email = isset($input['email']) ? $input['email'] : '';
+    $phone = isset($input['phone']) ? $input['phone'] : (isset($input['telefone']) ? $input['telefone'] : '');
+    $instagram = isset($input['instagram']) ? $input['instagram'] : '';
+
+    $name = trim((string) $name);
+    $email = strtolower(trim((string) $email));
+    $phone = trim((string) $phone);
+    $instagramHandle = normalize_instagram($instagram);
+
+    $phoneDigits = get_phone_digits($phone);
+
+    if ($email === '' && $phoneDigits === '') {
+        throw new InvalidArgumentException('Informe pelo menos e-mail ou telefone.');
+    }
+
+    return [
+        'name' => $name,
+        'email' => $email,
+        'phone' => $phone,
+        'instagram' => $instagramHandle,
+    ];
+}
+
+ensure_csv_file($CSV_FILE, $CSV_HEADERS);
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        $format = isset($_GET['format']) ? strtolower(trim($_GET['format'])) : '';
+        $download = isset($_GET['download']) ? strtolower(trim($_GET['download'])) : '';
+
+        if ($format === 'csv' || $download === '1' || $download === 'true') {
+            header('Content-Type: text/csv; charset=UTF-8');
+            header('Content-Disposition: attachment; filename="leads.csv"');
+            header('Cache-Control: no-store');
+            readfile($CSV_FILE);
+            exit;
+        }
+
+        $leads = read_leads_from_csv($CSV_FILE, $CSV_HEADERS);
+        header('Content-Type: application/json; charset=UTF-8');
+        header('Cache-Control: no-store');
+        echo json_encode(['leads' => $leads], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        http_response_code(405);
+        header('Allow: GET, POST, OPTIONS');
+        header('Content-Type: application/json; charset=UTF-8');
+        header('Cache-Control: no-store');
+        echo json_encode(['success' => false, 'message' => 'Método não permitido.']);
+        exit;
+    }
+
+    $rawBody = file_get_contents('php://input');
+    $input = json_decode($rawBody, true);
+
+    if (!is_array($input)) {
+        throw new InvalidArgumentException('Dados inválidos.');
+    }
+
+    $lead = normalize_input($input);
+    $leads = read_leads_from_csv($CSV_FILE, $CSV_HEADERS);
+    $timestamp = gmdate('c');
+    $phoneDigits = get_phone_digits($lead['phone']);
+    $updated = false;
+
+    foreach ($leads as &$existing) {
+        $existingPhoneDigits = get_phone_digits($existing['phone']);
+
+        if (
+            ($lead['email'] !== '' && strtolower($existing['email']) === $lead['email']) ||
+            ($phoneDigits !== '' && $existingPhoneDigits === $phoneDigits)
+        ) {
+            $existing['name'] = $lead['name'];
+            $existing['email'] = $lead['email'];
+            $existing['phone'] = $lead['phone'];
+            $existing['instagram'] = $lead['instagram'];
+            $existing['captured_at'] = $timestamp;
+            $updated = true;
+            break;
+        }
+    }
+
+    unset($existing);
+
+    if (!$updated) {
+        $lead['captured_at'] = $timestamp;
+        $leads[] = $lead;
+    }
+
+    write_leads_to_csv($CSV_FILE, $CSV_HEADERS, $leads);
+
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    http_response_code(201);
+    echo json_encode(['success' => true]);
+} catch (InvalidArgumentException $exception) {
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => $exception->getMessage()]);
+} catch (Throwable $exception) {
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Erro interno ao salvar o contato.']);
+}

--- a/server.js
+++ b/server.js
@@ -84,7 +84,7 @@ const escapeCsvValue = (value = '') => {
     return normalized;
 };
 
-const parseCsvLine = (line = '') => {
+const parseCsvLine = (line = '', delimiter = ',') => {
     const result = [];
     let current = '';
     let insideQuotes = false;
@@ -101,7 +101,7 @@ const parseCsvLine = (line = '') => {
             } else {
                 insideQuotes = !insideQuotes;
             }
-        } else if (char === ',' && !insideQuotes) {
+        } else if (char === delimiter && !insideQuotes) {
             result.push(current);
             current = '';
         } else {
@@ -122,14 +122,87 @@ const readLeadsFromCsv = async () => {
             return [];
         }
 
-        const [, ...rows] = lines;
+        const [rawHeader, ...rows] = lines;
+        const delimiter = (() => {
+            const firstDataRow = rows[0] || '';
+            const commaCount = (rawHeader.match(/,/g) || []).length + (firstDataRow.match(/,/g) || []).length;
+            const semicolonCount =
+                (rawHeader.match(/;/g) || []).length + (firstDataRow.match(/;/g) || []).length;
+
+            if (semicolonCount > commaCount) {
+                return ';';
+            }
+
+            if (commaCount > 0) {
+                return ',';
+            }
+
+            if (semicolonCount > 0) {
+                return ';';
+            }
+
+            // Default fallback when header does not contain delimiters.
+            return ',';
+        })();
+
+        const normalizeHeaderName = (value = '') =>
+            value
+                .toString()
+                .trim()
+                .toLowerCase()
+                .normalize('NFD')
+                .replace(/[\u0300-\u036f]/g, '')
+                .replace(/\s+/g, '_');
+
+        const resolveHeaderKey = (value = '') => {
+            const normalized = normalizeHeaderName(value);
+
+            if (['name', 'nome'].includes(normalized)) {
+                return 'name';
+            }
+
+            if (['email'].includes(normalized)) {
+                return 'email';
+            }
+
+            if (['phone', 'telefone', 'telefone_whatsapp', 'telefone_whats'].includes(normalized)) {
+                return 'phone';
+            }
+
+            if (['instagram', 'instagram_', 'instagram_handle'].includes(normalized)) {
+                return 'instagram';
+            }
+
+            if (
+                ['captured_at', 'data_registro', 'data_de_registro', 'registrado_em', 'capturado_em'].includes(
+                    normalized
+                )
+            ) {
+                return 'captured_at';
+            }
+
+            return null;
+        };
+
+        const headerColumns = parseCsvLine(rawHeader, delimiter);
+        const headerMap = headerColumns.map((column) => resolveHeaderKey(column));
 
         return rows.map((line) => {
-            const values = parseCsvLine(line);
+            const values = parseCsvLine(line, delimiter);
             const entry = {};
 
-            CSV_HEADERS.forEach((key, index) => {
+            headerMap.forEach((key, index) => {
+                if (!key) {
+                    return;
+                }
+
                 entry[key] = values[index] ?? '';
+            });
+
+            CSV_HEADERS.forEach((key) => {
+                if (entry[key] === undefined) {
+                    entry[key] = '';
+                }
             });
 
             return entry;


### PR DESCRIPTION
## Summary
- enhance the PHP leads endpoint to support GET/CSV responses and normalize stored records consistently
- add client-side fallbacks so the admin panel can list and export leads when the Node API is unavailable
- await the asynchronous CSV download in the admin UI to surface export errors properly

## Testing
- php -l leads.php

------
https://chatgpt.com/codex/tasks/task_e_68e0165aa330832ea6ce1051fc616da7