### PR TITLE
Improve admin lead export fallbacks

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -470,7 +470,7 @@
                     return;
                 }
 
-                downloadLeadsCsv();
+                await downloadLeadsCsv();
             } catch (error) {
                 console.error('Erro ao exportar os contatos.', error);
                 window.alert('Não foi possível exportar os contatos. Verifique a conexão com o servidor.');

--- a/lead-storage.js
+++ b/lead-storage.js
@@ -169,7 +169,19 @@
             options.headers['Content-Type'] = 'application/json';
         }
 
-        const response = await fetch(endpoint, options);
+        let response;
+
+        try {
+            response = await fetch(endpoint, options);
+        } catch (networkError) {
+            const error = new Error(
+                'Não foi possível se conectar ao servidor. Verifique sua conexão e tente novamente.'
+            );
+            error.status = 0;
+            error.endpoint = endpoint;
+            error.cause = networkError;
+            throw error;
+        }
 
         if (!response.ok) {
             let errorMessage = 'Erro desconhecido ao comunicar com o servidor.';
@@ -196,6 +208,49 @@
         }
 
         return null;
+    };
+
+    const collectEndpointCandidates = ({ includeCached = false } = {}) => {
+        const endpoints = [];
+        const seen = new Set();
+
+        const appendCandidate = (value) => {
+            if (typeof value !== 'string') {
+                return;
+            }
+
+            const trimmed = value.trim();
+
+            if (!trimmed || seen.has(trimmed)) {
+                return;
+            }
+
+            seen.add(trimmed);
+            endpoints.push(trimmed);
+        };
+
+        appendCandidate('./leads.php');
+
+        if (includeCached && cachedRegisterEndpoint) {
+            appendCandidate(cachedRegisterEndpoint);
+        }
+
+        appendCandidate(API_BASE);
+        FALLBACK_ENDPOINTS.forEach(appendCandidate);
+
+        if (typeof window !== 'undefined' && window.location && window.location.origin) {
+            FALLBACK_ENDPOINTS.forEach((path) => {
+                if (path.startsWith('http://') || path.startsWith('https://')) {
+                    appendCandidate(path);
+                    return;
+                }
+
+                const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+                appendCandidate(`${window.location.origin}${normalizedPath}`);
+            });
+        }
+
+        return endpoints;
     };
 
     const sendLeadRequest = async (endpoint, payload) => {
@@ -391,45 +446,8 @@
 
         setMessage('info', 'Enviando seus dados...');
 
-        const endpointsToTry = [];
-        const appendCandidate = (value) => {
-            if (typeof value !== 'string') {
-                return;
-            }
-
-            const trimmed = value.trim();
-
-            if (!trimmed) {
-                return;
-            }
-
-            if (!endpointsToTry.includes(trimmed)) {
-                endpointsToTry.push(trimmed);
-            }
-        };
-
-        appendCandidate('./leads.php');
-
-        if (cachedRegisterEndpoint) {
-            appendCandidate(cachedRegisterEndpoint);
-        }
-
-        appendCandidate(API_BASE);
-        FALLBACK_ENDPOINTS.forEach(appendCandidate);
-
-        if (typeof window !== 'undefined' && window.location && window.location.origin) {
-            FALLBACK_ENDPOINTS.forEach((path) => {
-                if (path.startsWith('http://') || path.startsWith('https://')) {
-                    appendCandidate(path);
-                    return;
-                }
-
-                const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-                appendCandidate(`${window.location.origin}${normalizedPath}`);
-            });
-        }
-
         const attempts = [];
+        const endpointsToTry = collectEndpointCandidates({ includeCached: true });
 
         for (const endpoint of endpointsToTry) {
             try {
@@ -516,23 +534,151 @@
     };
 
     const fetchLeads = async () => {
-        const data = await request(API_BASE, { method: 'GET' });
+        const attempts = [];
+        const endpoints = collectEndpointCandidates({ includeCached: true });
 
-        if (!data || !Array.isArray(data.leads)) {
-            return [];
+        for (const endpoint of endpoints) {
+            try {
+                const data = await request(endpoint, { method: 'GET' });
+
+                if (data && Array.isArray(data.leads)) {
+                    return data.leads;
+                }
+
+                if (data && Array.isArray(data)) {
+                    return data;
+                }
+
+                throw new Error('Resposta inválida do servidor.');
+            } catch (error) {
+                attempts.push({ endpoint, error });
+
+                const status = error && typeof error === 'object' ? error.status : undefined;
+
+                if (status === 404) {
+                    console.warn(
+                        `[tkLeadStorage] Endpoint ${endpoint} retornou 404 ao carregar leads. Tentando próximo endereço.`
+                    );
+                    continue;
+                }
+
+                console.error(
+                    `[tkLeadStorage] Erro ao carregar leads utilizando a rota ${endpoint}.`,
+                    error
+                );
+            }
         }
 
-        return data.leads;
+        const finalError = new Error('Não foi possível carregar os contatos.');
+        finalError.attempts = attempts;
+        throw finalError;
     };
 
-    const downloadLeadsCsv = () => {
-        const url = `${API_BASE}.csv?timestamp=${Date.now()}`;
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'leads.csv';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+    const buildCsvDownloadUrls = (endpoint) => {
+        const urls = [];
+        const seen = new Set();
+        const base = endpoint.split('#')[0];
+        const [withoutQuery, query = ''] = base.split('?');
+        const normalized = withoutQuery.replace(/\/$/, '');
+
+        const withTimestamp = (url) => {
+            const separator = url.includes('?') ? '&' : '?';
+            return `${url}${separator}timestamp=${Date.now()}`;
+        };
+
+        const appendUrl = (value) => {
+            if (!value || seen.has(value)) {
+                return;
+            }
+
+            seen.add(value);
+            urls.push(withTimestamp(value));
+        };
+
+        if (normalized.endsWith('.csv')) {
+            appendUrl(`${normalized}${query ? `?${query}` : ''}`);
+        } else {
+            appendUrl(`${normalized}.csv`);
+
+            if (normalized.endsWith('.php')) {
+                appendUrl(`${normalized}?format=csv`);
+                appendUrl(`${normalized}?download=1`);
+            }
+        }
+
+        return urls;
+    };
+
+    const downloadLeadsCsv = async () => {
+        const endpoints = collectEndpointCandidates({ includeCached: true });
+        const attempts = [];
+
+        for (const endpoint of endpoints) {
+            const candidates = buildCsvDownloadUrls(endpoint);
+
+            for (const candidate of candidates) {
+                try {
+                    const response = await fetch(candidate, {
+                        method: 'GET',
+                        headers: {
+                            Accept: 'text/csv, */*',
+                        },
+                    });
+
+                    if (!response.ok) {
+                        const error = new Error('Não foi possível baixar o arquivo CSV.');
+                        error.status = response.status;
+                        throw error;
+                    }
+
+                    const blob = await response.blob();
+
+                    if (!blob || blob.size === 0) {
+                        throw new Error('O arquivo CSV recebido está vazio.');
+                    }
+
+                    const disposition = response.headers.get('Content-Disposition') || '';
+                    const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
+                    const decodedFilename = filenameMatch
+                        ? decodeURIComponent(filenameMatch[1] || filenameMatch[2] || 'leads.csv')
+                        : 'leads.csv';
+
+                    const url = URL.createObjectURL(blob);
+                    const link = document.createElement('a');
+                    link.href = url;
+                    link.download = decodedFilename || 'leads.csv';
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+
+                    setTimeout(() => {
+                        URL.revokeObjectURL(url);
+                    }, 2000);
+
+                    return { endpoint: candidate, size: blob.size };
+                } catch (error) {
+                    attempts.push({ endpoint: candidate, error });
+
+                    const status = error && typeof error === 'object' ? error.status : undefined;
+
+                    if (status === 404) {
+                        console.warn(
+                            `[tkLeadStorage] CSV não encontrado em ${candidate}. Tentando próximo endereço disponível.`
+                        );
+                        continue;
+                    }
+
+                    console.error(
+                        `[tkLeadStorage] Erro ao baixar o CSV de ${candidate}.`,
+                        error
+                    );
+                }
+            }
+        }
+
+        const finalError = new Error('Não foi possível localizar uma fonte de download do CSV.');
+        finalError.attempts = attempts;
+        throw finalError;
     };
 
     window.tkLeadStorage = {

--- a/leads.php
+++ b/leads.php
@@ -1,34 +1,263 @@
 <?php
-header("Access-Control-Allow-Origin: *");
-header("Access-Control-Allow-Methods: POST");
-header("Access-Control-Allow-Headers: Content-Type");
-header("Content-Type: application/json; charset=UTF-8");
+declare(strict_types=1);
 
-$input = json_decode(file_get_contents("php://input"), true);
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With');
 
-if (!$input || !isset($input["nome"]) || !isset($input["telefone"]) || !isset($input["email"])) {
-    http_response_code(400);
-    echo json_encode(["error" => "Dados inválidos"]);
+$csvFile = __DIR__ . '/leads.csv';
+$csvHeaders = ['NAME', 'EMAIL', 'PHONE', 'INSTAGRAM', 'CAPTURED_AT'];
+
+$requestMethod = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
+$requestUri = $_SERVER['REQUEST_URI'] ?? '';
+$acceptHeader = $_SERVER['HTTP_ACCEPT'] ?? '';
+
+$sendJson = static function (int $status, array $payload): void {
+    http_response_code($status);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+};
+
+$ensureCsvFile = static function () use ($csvFile, $csvHeaders): void {
+    if (file_exists($csvFile)) {
+        return;
+    }
+
+    $handle = fopen($csvFile, 'wb');
+
+    if ($handle === false) {
+        throw new RuntimeException('Não foi possível preparar o arquivo de contatos.');
+    }
+
+    fputcsv($handle, $csvHeaders);
+    fclose($handle);
+};
+
+$normalizeHeaderName = static function (string $value): string {
+    $normalized = strtolower(trim($value));
+
+    if (function_exists('iconv')) {
+        $converted = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalized);
+        if ($converted !== false) {
+            $normalized = $converted;
+        }
+    }
+
+    $normalized = preg_replace('/[^a-z0-9]+/i', '_', $normalized);
+    return trim($normalized, '_');
+};
+
+$resolveHeaderKey = static function (string $value) use ($normalizeHeaderName): ?string {
+    $normalized = $normalizeHeaderName($value);
+
+    if (in_array($normalized, ['name', 'nome'], true)) {
+        return 'name';
+    }
+
+    if ($normalized === 'email') {
+        return 'email';
+    }
+
+    if (in_array($normalized, ['phone', 'telefone', 'telefone_whatsapp', 'telefone_whats'], true)) {
+        return 'phone';
+    }
+
+    if (in_array($normalized, ['instagram', 'instagram_', 'instagram_handle'], true)) {
+        return 'instagram';
+    }
+
+    if (
+        in_array(
+            $normalized,
+            ['captured_at', 'data_registro', 'data_de_registro', 'registrado_em', 'capturado_em'],
+            true
+        )
+    ) {
+        return 'captured_at';
+    }
+
+    return null;
+};
+
+$detectDelimiter = static function (string $headerLine, array $rows): string {
+    $firstRow = $rows[0] ?? '';
+    $commaCount = substr_count($headerLine, ',') + substr_count($firstRow, ',');
+    $semicolonCount = substr_count($headerLine, ';') + substr_count($firstRow, ';');
+
+    if ($semicolonCount > $commaCount) {
+        return ';';
+    }
+
+    if ($commaCount > 0) {
+        return ',';
+    }
+
+    if ($semicolonCount > 0) {
+        return ';';
+    }
+
+    return ',';
+};
+
+$parseCsv = static function () use (
+    $csvFile,
+    $ensureCsvFile,
+    $detectDelimiter,
+    $resolveHeaderKey
+) {
+    $ensureCsvFile();
+
+    if (!is_readable($csvFile)) {
+        throw new RuntimeException('Não foi possível abrir o arquivo de contatos.');
+    }
+
+    $content = file_get_contents($csvFile);
+
+    if ($content === false) {
+        throw new RuntimeException('Não foi possível ler o arquivo de contatos.');
+    }
+
+    $lines = preg_split('/\r\n|\n|\r/', $content) ?: [];
+    $lines = array_values(array_filter($lines, static fn ($line) => trim((string) $line) !== ''));
+
+    if (count($lines) <= 1) {
+        return [];
+    }
+
+    $header = array_shift($lines);
+    $delimiter = $detectDelimiter($header, $lines);
+    $headerColumns = str_getcsv($header, $delimiter);
+    $headerMap = array_map($resolveHeaderKey, $headerColumns);
+
+    $entries = [];
+
+    foreach ($lines as $line) {
+        $values = str_getcsv($line, $delimiter);
+        $entry = ['name' => '', 'email' => '', 'phone' => '', 'instagram' => '', 'captured_at' => ''];
+
+        foreach ($headerMap as $index => $key) {
+            if ($key === null) {
+                continue;
+            }
+
+            $entry[$key] = $values[$index] ?? '';
+        }
+
+        $entries[] = $entry;
+    }
+
+    return $entries;
+};
+
+$sendCsv = static function () use ($csvFile, $ensureCsvFile): void {
+    $ensureCsvFile();
+
+    if (!is_readable($csvFile)) {
+        throw new RuntimeException('Não foi possível abrir o arquivo de contatos.');
+    }
+
+    $size = filesize($csvFile);
+
+    if ($size === false) {
+        throw new RuntimeException('Não foi possível preparar o download do CSV.');
+    }
+
+    header('Content-Type: text/csv; charset=UTF-8');
+    header('Content-Disposition: attachment; filename="leads.csv"');
+    header('Content-Length: ' . $size);
+    header('Cache-Control: no-store');
+
+    $handle = fopen($csvFile, 'rb');
+
+    if ($handle === false) {
+        throw new RuntimeException('Não foi possível enviar o arquivo CSV.');
+    }
+
+    fpassthru($handle);
+    fclose($handle);
+};
+
+if ($requestMethod === 'OPTIONS') {
+    http_response_code(204);
     exit;
 }
 
-$nome = trim($input["nome"]);
-$telefone = trim($input["telefone"]);
-$email = trim($input["email"]);
-$instagram = isset($input["instagram"]) ? trim($input["instagram"]) : "";
+$wantsCsv = false;
 
-$arquivo = __DIR__ . "/leads.csv";
-
-if (!file_exists($arquivo)) {
-    $cabecalho = ["NAME", "EMAIL", "PHONE", "INSTAGRAM", "CAPTURED_AT"];
-    $fp = fopen($arquivo, "w");
-    fputcsv($fp, $cabecalho);
-    fclose($fp);
+if (preg_match('/\.csv(\?.*)?$/i', $requestUri)) {
+    $wantsCsv = true;
 }
 
-$fp = fopen($arquivo, "a");
-fputcsv($fp, [$nome, $email, $telefone, $instagram, date("c")]);
-fclose($fp);
+if (isset($_GET['format']) && strtolower((string) $_GET['format']) === 'csv') {
+    $wantsCsv = true;
+}
 
-http_response_code(201);
-echo json_encode(["success" => true, "message" => "Lead registrado com sucesso"]);
+if (isset($_GET['download'])) {
+    $wantsCsv = true;
+}
+
+if (!$wantsCsv && strpos($acceptHeader, 'text/csv') !== false && $requestMethod === 'GET') {
+    $wantsCsv = true;
+}
+
+try {
+    if ($requestMethod === 'GET') {
+        if ($wantsCsv) {
+            $sendCsv();
+            exit;
+        }
+
+        $entries = $parseCsv();
+        $sendJson(200, ['leads' => $entries]);
+        exit;
+    }
+
+    if ($requestMethod !== 'POST') {
+        $sendJson(405, ['success' => false, 'message' => 'Método não permitido.']);
+        exit;
+    }
+
+    $ensureCsvFile();
+
+    $rawBody = file_get_contents('php://input') ?: '';
+
+    $input = json_decode($rawBody, true);
+
+    if (!is_array($input)) {
+        $sendJson(400, ['success' => false, 'message' => 'Corpo da requisição inválido.']);
+        exit;
+    }
+
+    $nome = isset($input['nome']) ? trim((string) $input['nome']) : '';
+    $telefone = isset($input['telefone']) ? trim((string) $input['telefone']) : '';
+    $email = isset($input['email']) ? trim((string) $input['email']) : '';
+    $instagram = isset($input['instagram']) ? trim((string) $input['instagram']) : '';
+
+    if ($nome === '' || $telefone === '' || $email === '') {
+        $sendJson(400, ['success' => false, 'message' => 'Dados inválidos.']);
+        exit;
+    }
+
+    $handle = fopen($csvFile, 'ab');
+
+    if ($handle === false) {
+        throw new RuntimeException('Não foi possível registrar o contato.');
+    }
+
+    fputcsv($handle, [$nome, $email, $telefone, $instagram, date('c')]);
+    fclose($handle);
+
+    $sendJson(201, ['success' => true, 'message' => 'Lead registrado com sucesso']);
+} catch (Throwable $error) {
+    if ($wantsCsv) {
+        http_response_code(500);
+        header('Content-Type: text/plain; charset=UTF-8');
+        echo 'Erro ao gerar o arquivo CSV.';
+        exit;
+    }
+
+    $sendJson(500, [
+        'success' => false,
+        'message' => $error->getMessage() ?: 'Erro interno ao processar a requisição.',
+    ]);
+}


### PR DESCRIPTION
## Summary
- teach the PHP leads endpoint to respond to OPTIONS/GET/POST, normalize CSV data, and stream downloads so the admin can work without the Node server
- add client-side fallbacks that try both Node and PHP URLs when listing and exporting leads, including resilient CSV download handling
- await the asynchronous CSV export from the admin page so download failures surface to the user

## Testing
- php -l leads.php

------
https://chatgpt.com/codex/tasks/task_e_68e01a9da9bc832e93c33266791aa6e8